### PR TITLE
Add MakeDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
 version: '3.8'
 services:
   db:
-    build: ../RaiseTech#7/docker-mysql-hands-on
-    container_name: docker-mysql-hands-on
+    build: .
+    container_name: name_db_container
     platform: linux/x86_64
     command: --default-authentication-plugin=mysql_native_password
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: movie_list
+      MYSQL_DATABASE: name_database
       MYSQL_USER: user
       MYSQL_PASSWORD: password
     ports:

--- a/sql/001-create-table-and-load-data.sql
+++ b/sql/001-create-table-and-load-data.sql
@@ -1,11 +1,8 @@
-DROP TABLE IF EXISTS movies;
-
-CREATE TABLE movies (
-  id int unsigned AUTO_INCREMENT,
-  name VARCHAR(100) NOT NULL,
-  director VARCHAR(100) NOT NULL,
-  PRIMARY KEY(id)
+DROP TABLE IF EXISTS names;
+CREATE TABLE names (
+ id int unsigned AUTO_INCREMENT,
+ name VARCHAR(20) NOT NULL,
+ PRIMARY KEY(id)
 );
-
-INSERT INTO movies (name, director) VALUES ("ショーシャンクの空に", "フランク・ダラボン");
-INSERT INTO movies (name, director) VALUES ("この世界の片隅に", "片渕須直");
+INSERT INTO names (name) VALUES ('name1');
+INSERT INTO names (name) VALUES ('name2');


### PR DESCRIPTION
#概要

MySQLのDBと初期テーブルの作成ができるようDocker関連ファイルお作成をしました。

#動作確認
mysql> show databases;
+--------------------+
| Database           |
+--------------------+
| information_schema |
| mysql              |
| name_database      |
| performance_schema |
| sys                |
+--------------------+
5 rows in set (0.00 sec)

mysql> use name_database;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
mysql> show tables;
+-------------------------+
| Tables_in_name_database |
+-------------------------+
| names                   |
+-------------------------+
1 row in set (0.00 sec)

mysql> select * from names;
+----+-------+
| id | name  |
+----+-------+
|  1 | name1 |
|  2 | name2 |
+----+-------+
2 rows in set (0.00 sec)